### PR TITLE
Fix logic in getState with invert_status true

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ class CommandAccessoryPlugin {
       execSync(this.config.check_status, { timeout: timeout });
       this.currentState = !this.config.invert_status;
     } catch (error) {
-      this.currentState = false;
+      this.currentState = this.config.invert_status;
     }
 
     this.log.debug(`Returning: ${this.currentState}`);


### PR DESCRIPTION
Currently, getStatus will always return false if check_status is defined and invert_status is true. This pull request resolves the logic error.